### PR TITLE
Harden scraper follow-ups and rendered data

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,14 +163,14 @@
           ? `${c.distance_from_roslindale_miles} mi` : '—';
 
         const yearCell = c.data_is_stale
-          ? `<span class="badge stale-badge" title="Info from ${c.data_year}. Verify with camp directly.">${c.data_year} ⚠</span>`
-          : `<span class="badge current-badge">${c.data_year || '—'}</span>`;
+          ? `<span class="badge stale-badge" title="Info from ${esc(c.data_year)}. Verify with camp directly.">${esc(c.data_year)} ⚠</span>`
+          : `<span class="badge current-badge">${esc(c.data_year)}</span>`;
 
         const aid = c.financial_aid_available === true ? 'Yes'
           : c.financial_aid_available === false ? 'No' : '—';
 
         tr.innerHTML = `
-          <td><a href="${safeUrl(c.website_url)}" target="_blank" rel="noopener">${esc(c.camp_name)}</a></td>
+          <td><a href="${esc(safeUrl(c.website_url))}" target="_blank" rel="noopener">${esc(c.camp_name)}</a></td>
           <td>${esc(c.organization)}</td>
           <td>${esc(c.camp_type)}</td>
           <td>${esc(c.neighborhood)}</td>
@@ -181,7 +181,7 @@
           <td>${esc(c.cost_per_week)}</td>
           <td>${esc(c.signup_opens)}</td>
           <td>${aid}</td>
-          <td>${c.signup_url ? `<a href="${safeUrl(c.signup_url)}" target="_blank" rel="noopener">Register →</a>` : '—'}</td>
+          <td>${c.signup_url ? `<a href="${esc(safeUrl(c.signup_url))}" target="_blank" rel="noopener">Register →</a>` : '—'}</td>
           <td>${yearCell}</td>
         `;
         tbody.appendChild(tr);

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,6 +1,8 @@
 import json
 import time
 from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urldefrag, urljoin, urlparse
 
 import anthropic
 
@@ -10,6 +12,19 @@ from scraper.geocoder import distance_from_roslindale
 from scraper.sources import SOURCES
 
 MAX_HOPS = 5
+
+
+def safe_follow_url(source_url: str, current_url: str, follow_url: str) -> Optional[str]:
+    resolved = urljoin(current_url, follow_url)
+    resolved, _ = urldefrag(resolved)
+    source = urlparse(source_url)
+    candidate = urlparse(resolved)
+
+    if candidate.scheme not in ("http", "https"):
+        return None
+    if candidate.netloc.lower() != source.netloc.lower():
+        return None
+    return resolved
 
 
 def scrape_source(source: dict, client: anthropic.Anthropic) -> list[dict]:
@@ -46,8 +61,9 @@ def scrape_source(source: dict, client: anthropic.Anthropic) -> list[dict]:
             break
 
         for follow_url in result.get("follow_up_urls", []):
-            if follow_url not in visited:
-                queue.append(follow_url)
+            safe_url = safe_follow_url(source["url"], url, follow_url)
+            if safe_url and safe_url not in visited:
+                queue.append(safe_url)
 
         hop += 1
         time.sleep(1)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,7 +1,7 @@
 import json
 import os
 from unittest.mock import MagicMock, patch
-from scraper.scraper import MAX_HOPS, scrape_source, run_scraper
+from scraper.scraper import MAX_HOPS, safe_follow_url, scrape_source, run_scraper
 
 
 def _make_client() -> MagicMock:
@@ -65,6 +65,40 @@ def test_scrape_source_respects_max_depth():
         result = scrape_source(source, _make_client())
 
     assert hop == MAX_HOPS
+
+
+def test_safe_follow_url_allows_same_origin_links():
+    source_url = "https://example.com/camps"
+    current_url = "https://example.com/camps/summer"
+
+    assert safe_follow_url(source_url, current_url, "/register#top") == "https://example.com/register"
+
+
+def test_safe_follow_url_rejects_cross_origin_and_non_http_links():
+    source_url = "https://example.com/camps"
+    current_url = "https://example.com/camps/summer"
+
+    assert safe_follow_url(source_url, current_url, "https://attacker.test/collect") is None
+    assert safe_follow_url(source_url, current_url, "javascript:alert(1)") is None
+
+
+def test_scrape_source_skips_cross_origin_follow_up_urls():
+    source = {"name": "Test Org", "url": "https://example.com"}
+
+    call_count = 0
+    def fake_extract(client, url, org, content):
+        nonlocal call_count
+        call_count += 1
+        return _extractor_result(
+            follow_ups=["https://attacker.test/collect"],
+            sufficient=False,
+        )
+
+    with patch("scraper.scraper.fetch_page", return_value="content"), \
+         patch("scraper.scraper.extract_camps", side_effect=fake_extract):
+        scrape_source(source, _make_client())
+
+    assert call_count == 1
 
 
 def test_scrape_source_skips_visited_urls():


### PR DESCRIPTION
## Summary
- escape scraped URL and year values before interpolating them into table HTML attributes
- restrict scraper follow-up URLs to same-origin HTTP(S) links from the configured source
- add tests for same-origin follow-ups, rejected cross-origin/non-HTTP links, and max-hop behavior

## Testing
- python3 -m pytest
- node frontend escaping harness with quote-bearing URL values