### PR TITLE
Reduce scheduled scrape costs

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -2,7 +2,7 @@ name: Scrape Camp Data
 
 on:
   schedule:
-    - cron: '0 11 * * 0'   # Sundays 6am ET (UTC-5 in winter, UTC-4 in summer)
+    - cron: '0 11 * * 0'   # Sundays; scheduled scraper runs only on even ISO weeks
   workflow_dispatch:          # enable manual trigger from GitHub Actions tab
 
 jobs:
@@ -16,20 +16,40 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Check biweekly schedule
+        id: biweekly
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          week="$(date -u '+%V')"
+          if [ $((10#$week % 2)) -eq 0 ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping scheduled scrape on odd ISO week $week"
+          fi
+
       - name: Set up Python 3.13
+        if: steps.biweekly.outputs.should_run == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
 
       - name: Install dependencies
+        if: steps.biweekly.outputs.should_run == 'true'
         run: pip install -r requirements.txt
 
       - name: Run scraper
+        if: steps.biweekly.outputs.should_run == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python -m scraper.scraper
 
       - name: Commit updated data.json
+        if: steps.biweekly.outputs.should_run == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Boston Camp Finder
 
-Weekly-updated aggregator of kids' camps near Roslindale, MA.
+Biweekly-updated aggregator of kids' camps near Roslindale, MA.
 
 **Live site:** https://timothyryanhall.github.io/boston-camp-finder/
 
-Data is scraped every Sunday from 16 Boston-area organizations using Claude for extraction.
+Data is scraped every other Sunday from 16 Boston-area organizations using Claude for extraction.
 To add a new source, add one entry to `scraper/sources.py`.
 
 ## Setup

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 </head>
 <body>
   <h1>Boston Camp Finder</h1>
-  <p class="subtitle">Kids' camps near Roslindale, aggregated weekly from 16 Boston-area organizations. Always verify details directly with the camp.</p>
+  <p class="subtitle">Kids' camps near Roslindale, aggregated every other week from 16 Boston-area organizations. Always verify details directly with the camp.</p>
 
   <div class="filters">
     <label>
@@ -76,7 +76,7 @@
   </table>
 
   <footer>
-    Data scraped weekly via GitHub Actions using Claude. Information may be from a prior year — check directly with each camp before registering.
+    Data scraped every other week via GitHub Actions using Claude. Information may be from a prior year — check directly with each camp before registering.
     <span id="footer-last-scraped"></span>
   </footer>
 

--- a/scraper/extractor.py
+++ b/scraper/extractor.py
@@ -65,7 +65,7 @@ def extract_camps(
     )
     try:
         message = client.messages.create(
-            model="claude-sonnet-4-6",
+            model="claude-haiku-4-5-20251001",
             max_tokens=4096,
             messages=[{"role": "user", "content": prompt}],
         )


### PR DESCRIPTION
## Summary
- switch camp extraction from Claude Sonnet to Claude Haiku 4.5
- gate scheduled scrapes so they only run every other ISO week
- keep manual workflow dispatch enabled and avoid push-triggered scraper runs
- update site and README copy from weekly to every other week

## Testing
- python3 -m pytest