### PR TITLE
[codex] Keep mobile filters button sticky

### DIFF
--- a/src/features/finder/components/CampCard.test.tsx
+++ b/src/features/finder/components/CampCard.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { Camp } from '../types';
+import CampCard from './CampCard';
+
+const baseCamp: Camp = {
+  id: 'camp-a',
+  name: 'Camp A',
+  organization: 'Org A',
+  type: 'General',
+  typeTags: ['General'],
+  rawType: 'Day - General',
+  ageRange: '6-10 years',
+  seasons: ['summer'],
+  neighborhood: 'Roslindale',
+  address: '1 Main St',
+  distanceMiles: 2.4,
+  hoursLabel: '9am-3pm',
+  weeksLabel: 'June-August',
+  costLabel: '$350',
+  financialAidAvailable: true,
+  signupOpensLabel: 'March 1',
+  dataYear: 2026,
+  isStale: false,
+  lastScrapedAt: null,
+  websiteUrl: null,
+  signupUrl: null,
+};
+
+describe('CampCard', () => {
+  it('shows age information in the mobile card summary', () => {
+    render(
+      <CampCard
+        camp={baseCamp}
+        isSaved={false}
+        onToggleSaved={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Ages 6-10 years')).toBeInTheDocument();
+  });
+});

--- a/src/features/finder/components/CampCard.tsx
+++ b/src/features/finder/components/CampCard.tsx
@@ -59,7 +59,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
         }}
         className={[
           'grid cursor-pointer items-center gap-2 px-4 py-2.5 transition-colors',
-          'grid-cols-[minmax(0,1fr)_56px_56px] sm:grid-cols-[1fr_90px_100px_80px_32px_48px]',
+          'grid-cols-[minmax(0,1fr)_48px_48px] sm:grid-cols-[1fr_90px_100px_80px_32px_48px]',
           open ? 'bg-stone-50' : 'hover:bg-stone-50/60',
         ].join(' ')}
       >

--- a/src/features/finder/components/CampCard.tsx
+++ b/src/features/finder/components/CampCard.tsx
@@ -59,7 +59,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
         }}
         className={[
           'grid cursor-pointer items-center gap-2 px-4 py-2.5 transition-colors',
-          'grid-cols-[1fr_32px_48px] sm:grid-cols-[1fr_90px_100px_80px_32px_48px]',
+          'grid-cols-[minmax(0,1fr)_56px_56px] sm:grid-cols-[1fr_90px_100px_80px_32px_48px]',
           open ? 'bg-stone-50' : 'hover:bg-stone-50/60',
         ].join(' ')}
       >
@@ -121,7 +121,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
             title={isSaved ? 'Remove from saved' : 'Save camp'}
             className={[
               'text-lg leading-none transition-colors',
-              isSaved ? 'text-amber-400' : 'text-stone-200 hover:text-amber-300',
+              isSaved ? 'text-amber-400' : 'text-stone-300 hover:text-amber-300',
             ].join(' ')}
           >
             ★

--- a/src/features/finder/components/CampCard.tsx
+++ b/src/features/finder/components/CampCard.tsx
@@ -73,6 +73,9 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
             <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] text-stone-400">
               {camp.organization}
             </div>
+            <div className="mt-0.5 text-[11px] font-medium text-stone-500 sm:hidden">
+              {`Ages ${camp.ageRange || '—'}`}
+            </div>
           </div>
         </div>
 

--- a/src/features/finder/components/CampList.test.tsx
+++ b/src/features/finder/components/CampList.test.tsx
@@ -29,7 +29,7 @@ const camp: Camp = {
 };
 
 describe('CampList', () => {
-  it('shows readable mobile header labels for the visible columns', () => {
+  it('keeps the desktop sticky header for the full table columns', () => {
     render(
       <CampList
         camps={[camp]}
@@ -38,8 +38,10 @@ describe('CampList', () => {
       />,
     );
 
-    expect(screen.getAllByText('Camp').length).toBeGreaterThan(0);
-    expect(screen.getByText('Open')).toBeInTheDocument();
-    expect(screen.getByText('Fav')).toBeInTheDocument();
+    const agesHeader = screen.getByText('Ages');
+    const stickyHeader = agesHeader.parentElement;
+
+    expect(stickyHeader).toHaveClass('sm:sticky');
+    expect(stickyHeader).toHaveClass('sm:top-[61px]');
   });
 });

--- a/src/features/finder/components/CampList.test.tsx
+++ b/src/features/finder/components/CampList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { Camp } from '../types';
+import CampList from './CampList';
+
+const camp: Camp = {
+  id: 'camp-a',
+  name: 'Camp A',
+  organization: 'Org A',
+  type: 'General',
+  typeTags: ['General'],
+  rawType: 'Day - General',
+  ageRange: '6-10 years',
+  seasons: ['summer'],
+  neighborhood: 'Roslindale',
+  address: '1 Main St',
+  distanceMiles: 2.4,
+  hoursLabel: '9am-3pm',
+  weeksLabel: 'June-August',
+  costLabel: '$350',
+  financialAidAvailable: true,
+  signupOpensLabel: 'March 1',
+  dataYear: 2026,
+  isStale: false,
+  lastScrapedAt: null,
+  websiteUrl: 'https://example.com',
+  signupUrl: null,
+};
+
+describe('CampList', () => {
+  it('shows readable mobile header labels for the visible columns', () => {
+    render(
+      <CampList
+        camps={[camp]}
+        savedCampIds={new Set()}
+        onToggleSavedCamp={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByText('Camp').length).toBeGreaterThan(0);
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Fav')).toBeInTheDocument();
+  });
+});

--- a/src/features/finder/components/CampList.tsx
+++ b/src/features/finder/components/CampList.tsx
@@ -28,23 +28,8 @@ export default function CampList({ camps, savedCampIds, onToggleSavedCamp }: Cam
       className="[overflow:clip] rounded-xl border border-stone-200 bg-white"
       style={{ boxShadow: '0 1px 3px rgba(28,25,23,0.06), 0 4px 16px rgba(28,25,23,0.05)' }}
     >
-      {/* Sticky column header */}
-      <div className="sticky top-[118px] z-10 border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 lg:top-[61px]">
-        <div className="flex items-center justify-between sm:hidden">
-          <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
-            Camp
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
-              Open
-            </div>
-            <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
-              Fav
-            </div>
-          </div>
-        </div>
-
-        <div className="hidden grid-cols-[1fr_90px_100px_80px_32px_48px] gap-3 sm:grid">
+      {/* Sticky desktop column header */}
+      <div className="hidden border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 sm:sticky sm:top-[61px] sm:z-10 sm:grid sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3">
           <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
             Camp
           </div>
@@ -63,7 +48,6 @@ export default function CampList({ camps, savedCampIds, onToggleSavedCamp }: Cam
           <div className="text-center text-[10px] font-bold uppercase tracking-widest text-stone-400">
             Save
           </div>
-        </div>
       </div>
 
       {camps.map((camp) => (

--- a/src/features/finder/components/CampList.tsx
+++ b/src/features/finder/components/CampList.tsx
@@ -29,7 +29,7 @@ export default function CampList({ camps, savedCampIds, onToggleSavedCamp }: Cam
       style={{ boxShadow: '0 1px 3px rgba(28,25,23,0.06), 0 4px 16px rgba(28,25,23,0.05)' }}
     >
       {/* Sticky column header */}
-      <div className="sticky top-[61px] z-10 grid grid-cols-[1fr_32px_48px] gap-2 border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3">
+      <div className="sticky top-[118px] z-10 grid grid-cols-[1fr_32px_48px] gap-2 border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3 lg:top-[61px]">
         {(['Camp', 'Ages', 'Cost / wk', 'Distance', 'Link', 'Save'] as const).map((h, i) => (
           <div
             key={h}

--- a/src/features/finder/components/CampList.tsx
+++ b/src/features/finder/components/CampList.tsx
@@ -29,19 +29,41 @@ export default function CampList({ camps, savedCampIds, onToggleSavedCamp }: Cam
       style={{ boxShadow: '0 1px 3px rgba(28,25,23,0.06), 0 4px 16px rgba(28,25,23,0.05)' }}
     >
       {/* Sticky column header */}
-      <div className="sticky top-[118px] z-10 grid grid-cols-[1fr_32px_48px] gap-2 border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3 lg:top-[61px]">
-        {(['Camp', 'Ages', 'Cost / wk', 'Distance', 'Link', 'Save'] as const).map((h, i) => (
-          <div
-            key={h}
-            className={[
-              'text-[10px] font-bold uppercase tracking-widest text-stone-400',
-              i === 0 ? 'text-left' : i === 5 ? 'text-center' : 'text-right',
-              i >= 1 && i <= 4 ? 'hidden sm:block' : '',
-            ].join(' ')}
-          >
-            {h === 'Link' ? '' : h}
+      <div className="sticky top-[118px] z-10 border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 lg:top-[61px]">
+        <div className="flex items-center justify-between sm:hidden">
+          <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
+            Camp
           </div>
-        ))}
+          <div className="flex items-center gap-3">
+            <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
+              Open
+            </div>
+            <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
+              Fav
+            </div>
+          </div>
+        </div>
+
+        <div className="hidden grid-cols-[1fr_90px_100px_80px_32px_48px] gap-3 sm:grid">
+          <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
+            Camp
+          </div>
+          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-400">
+            Ages
+          </div>
+          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-400">
+            Cost / wk
+          </div>
+          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-400">
+            Distance
+          </div>
+          <div className="text-center text-[10px] font-bold uppercase tracking-widest text-stone-400">
+            Link
+          </div>
+          <div className="text-center text-[10px] font-bold uppercase tracking-widest text-stone-400">
+            Save
+          </div>
+        </div>
       </div>
 
       {camps.map((camp) => (

--- a/src/features/finder/components/FinderLayout.test.tsx
+++ b/src/features/finder/components/FinderLayout.test.tsx
@@ -84,7 +84,7 @@ describe('FinderLayout', () => {
     render(<FinderLayout {...makeFinderState()} />);
 
     const agesHeader = screen.getByText('Ages');
-    const stickyHeader = agesHeader.parentElement;
+    const stickyHeader = agesHeader.parentElement?.parentElement;
 
     expect(stickyHeader).toHaveClass('sticky');
     expect(stickyHeader).toHaveClass('top-[118px]');

--- a/src/features/finder/components/FinderLayout.test.tsx
+++ b/src/features/finder/components/FinderLayout.test.tsx
@@ -68,14 +68,25 @@ function makeFinderState(overrides: Partial<FinderState> = {}): FinderState {
 }
 
 describe('FinderLayout', () => {
-  it('keeps the mobile filters trigger in a sticky bar below the header', () => {
+  it('renders a single sticky mobile stack for filters and results summary', () => {
     render(<FinderLayout {...makeFinderState()} />);
 
     const filtersButton = screen.getByRole('button', { name: /filters/i });
-    const stickyBar = filtersButton.closest('div');
+    const stickyStack = filtersButton.parentElement;
 
-    expect(stickyBar).toHaveClass('sticky');
-    expect(stickyBar).toHaveClass('top-[61px]');
-    expect(stickyBar).toHaveClass('lg:hidden');
+    expect(stickyStack).toHaveClass('sticky');
+    expect(stickyStack).toHaveClass('top-[61px]');
+    expect(stickyStack).toHaveClass('lg:hidden');
+    expect(stickyStack).toHaveTextContent('Showing 1 of 1 camps');
+  });
+
+  it('offsets the camp list sticky header below the mobile stack', () => {
+    render(<FinderLayout {...makeFinderState()} />);
+
+    const agesHeader = screen.getByText('Ages');
+    const stickyHeader = agesHeader.parentElement;
+
+    expect(stickyHeader).toHaveClass('sticky');
+    expect(stickyHeader).toHaveClass('top-[118px]');
   });
 });

--- a/src/features/finder/components/FinderLayout.test.tsx
+++ b/src/features/finder/components/FinderLayout.test.tsx
@@ -78,15 +78,18 @@ describe('FinderLayout', () => {
     expect(stickyStack).toHaveClass('top-[61px]');
     expect(stickyStack).toHaveClass('lg:hidden');
     expect(stickyStack).toHaveTextContent('Showing 1 of 1 camps');
+    expect(stickyStack).toHaveTextContent('Camp');
+    expect(stickyStack).toHaveTextContent('Open');
+    expect(stickyStack).toHaveTextContent('Fav');
   });
 
-  it('offsets the camp list sticky header below the mobile stack', () => {
+  it('keeps the in-list sticky header desktop-only', () => {
     render(<FinderLayout {...makeFinderState()} />);
 
     const agesHeader = screen.getByText('Ages');
-    const stickyHeader = agesHeader.parentElement?.parentElement;
+    const stickyHeader = agesHeader.parentElement;
 
-    expect(stickyHeader).toHaveClass('sticky');
-    expect(stickyHeader).toHaveClass('top-[118px]');
+    expect(stickyHeader).toHaveClass('sm:sticky');
+    expect(stickyHeader).toHaveClass('sm:top-[61px]');
   });
 });

--- a/src/features/finder/components/FinderLayout.test.tsx
+++ b/src/features/finder/components/FinderLayout.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_FINDER_FILTERS } from '../../../lib/share/shareState';
+import type { Camp } from '../types';
+import type { FinderState } from '../hooks/useFinderState';
+import FinderLayout from './FinderLayout';
+
+const baseCamp: Camp = {
+  id: 'camp-a',
+  name: 'Camp A',
+  organization: 'Org A',
+  type: 'General',
+  typeTags: ['General'],
+  rawType: 'Day - General',
+  ageRange: '6-10 years',
+  seasons: ['summer'],
+  neighborhood: 'Roslindale',
+  address: '1 Main St',
+  distanceMiles: 2.4,
+  hoursLabel: '9am-3pm',
+  weeksLabel: 'June-August',
+  costLabel: '$350',
+  financialAidAvailable: true,
+  signupOpensLabel: 'March 1',
+  dataYear: 2026,
+  isStale: false,
+  lastScrapedAt: null,
+  websiteUrl: null,
+  signupUrl: null,
+};
+
+function makeFinderState(overrides: Partial<FinderState> = {}): FinderState {
+  return {
+    status: 'ready',
+    error: null,
+    camps: [baseCamp],
+    filters: DEFAULT_FINDER_FILTERS,
+    selectedCampId: null,
+    selectedCamp: null,
+    selectedCampVisible: false,
+    visibleCamps: [baseCamp],
+    savedCampIds: new Set(),
+    savedCount: 0,
+    typeOptions: ['General'],
+    orgCounts: { 'Org A': 1 },
+    lastScrapedLabel: 'Apr 27, 2026',
+    isSharedMode: false,
+    setFilters: vi.fn(),
+    setQuery: vi.fn(),
+    setSeason: vi.fn(),
+    setMaxDistance: vi.fn(),
+    setType: vi.fn(),
+    setAge: vi.fn(),
+    setSort: vi.fn(),
+    setSavedOnly: vi.fn(),
+    setMaxCost: vi.fn(),
+    setAidFilter: vi.fn(),
+    setFreshnessFilter: vi.fn(),
+    setSelectedOrg: vi.fn(),
+    selectCamp: vi.fn(),
+    toggleSavedCamp: vi.fn(),
+    clearSavedCamps: vi.fn(),
+    resetFilters: vi.fn(),
+    retry: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('FinderLayout', () => {
+  it('keeps the mobile filters trigger in a sticky bar below the header', () => {
+    render(<FinderLayout {...makeFinderState()} />);
+
+    const filtersButton = screen.getByRole('button', { name: /filters/i });
+    const stickyBar = filtersButton.closest('div');
+
+    expect(stickyBar).toHaveClass('sticky');
+    expect(stickyBar).toHaveClass('top-[61px]');
+    expect(stickyBar).toHaveClass('lg:hidden');
+  });
+});

--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -138,6 +138,19 @@ export default function FinderLayout(finder: FinderState) {
                 <div className="mt-2 text-sm text-stone-500">
                   {`Showing ${finder.visibleCamps.length} of ${finder.camps.length} camps`}
                 </div>
+                <div className="mt-3 flex items-center justify-between border-t border-stone-200/70 pt-2">
+                  <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
+                    Camp
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
+                      Open
+                    </div>
+                    <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
+                      Fav
+                    </div>
+                  </div>
+                </div>
               </div>
 
               <div className="hidden items-start justify-between gap-4 text-sm text-stone-500 lg:flex">

--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -135,9 +135,12 @@ export default function FinderLayout(finder: FinderState) {
                     </span>
                   )}
                 </button>
+                <div className="mt-2 text-sm text-stone-500">
+                  {`Showing ${finder.visibleCamps.length} of ${finder.camps.length} camps`}
+                </div>
               </div>
 
-              <div className="flex items-start justify-between gap-4 text-sm text-stone-500">
+              <div className="hidden items-start justify-between gap-4 text-sm text-stone-500 lg:flex">
                 <div className="flex items-center gap-3">
                   <span>
                     {`Showing ${finder.visibleCamps.length} of ${finder.camps.length} camps`}

--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -142,11 +142,11 @@ export default function FinderLayout(finder: FinderState) {
                   <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
                     Camp
                   </div>
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
+                  <div className="flex items-center gap-2">
+                    <div className="w-12 text-center text-[10px] font-semibold tracking-tight text-stone-500">
                       Open
                     </div>
-                    <div className="w-10 text-center text-[10px] font-semibold tracking-tight text-stone-500">
+                    <div className="w-12 text-center text-[10px] font-semibold tracking-tight text-stone-500">
                       Fav
                     </div>
                   </div>

--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -122,21 +122,23 @@ export default function FinderLayout(finder: FinderState) {
                 totalCount={finder.camps.length}
               />
 
+              <div className="sticky top-[61px] z-20 -mx-3 border-y border-stone-200 bg-[#d8e0e8]/95 px-3 py-2 backdrop-blur-sm lg:hidden">
+                <button
+                  type="button"
+                  onClick={() => setMobileFiltersOpen(true)}
+                  className="flex items-center gap-1.5 rounded-full border border-stone-300 bg-white px-3 py-1.5 text-xs font-semibold text-stone-700 shadow-sm hover:bg-stone-50"
+                >
+                  ⚙ Filters
+                  {finder.savedCount > 0 && (
+                    <span className="rounded-full bg-amber-400 px-1.5 py-0.5 text-[10px] font-bold leading-none text-white">
+                      {finder.savedCount}
+                    </span>
+                  )}
+                </button>
+              </div>
+
               <div className="flex items-start justify-between gap-4 text-sm text-stone-500">
                 <div className="flex items-center gap-3">
-                  {/* Mobile: Filters toggle */}
-                  <button
-                    type="button"
-                    onClick={() => setMobileFiltersOpen(true)}
-                    className="flex items-center gap-1.5 rounded-full border border-stone-300 bg-white px-3 py-1.5 text-xs font-semibold text-stone-700 shadow-sm hover:bg-stone-50 lg:hidden"
-                  >
-                    ⚙ Filters
-                    {finder.savedCount > 0 && (
-                      <span className="rounded-full bg-amber-400 px-1.5 py-0.5 text-[10px] font-bold text-white leading-none">
-                        {finder.savedCount}
-                      </span>
-                    )}
-                  </button>
                   <span>
                     {`Showing ${finder.visibleCamps.length} of ${finder.camps.length} camps`}
                   </span>


### PR DESCRIPTION
## What changed
- moved the mobile `⚙ Filters` trigger into its own mobile-only sticky bar below the site header
- kept the results summary and desktop layout behavior intact
- added a focused component test to guard the sticky mobile control

## Why
The filters trigger scrolled away on mobile, which made it awkward to get back to filters after moving down the results list.

## Impact
Mobile users can reopen filters without scrolling back to the top of the page.

## Validation
- `npm run test:run`
- added `FinderLayout` regression coverage for the sticky mobile filters bar