### PR TITLE
[codex] Refresh README and add parent-run note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,65 @@
 # Boston Camp Finder
 
-Biweekly-updated aggregator of kids' camps near Roslindale, MA.
+Camp search for Boston-area families, centered on camps near Roslindale.
 
 **Live site:** https://bostoncampfinder.com
 
-Data is scraped every other Sunday from 16 Boston-area organizations using Claude for extraction.
-To add a new source, add one entry to `scraper/sources.py`.
+Boston Camp Finder is run by Boston-area parents who got tired of digging through scattered camp listings and stale websites.
+
+The site combines a searchable React frontend, a periodic scraper that refreshes `data.json`, and a small feedback API for suggestions and corrections.
+
+Data is scraped every other Sunday from Boston-area organizations using Claude for extraction. To add a new source, add one entry to `scraper/sources.py`.
 
 ## Architecture
 
 | Layer | Tech |
 |-------|------|
-| Frontend | Static HTML/CSS/JS (`index.html`) |
-| Hosting | Vercel (deployed from `main`) |
+| Frontend | Vite + React + TypeScript + React Router + Tailwind (`src/`) |
+| Hosting | Vercel |
 | API | Vercel Serverless Functions (`api/`) |
 | Database | Neon Postgres (via Vercel Storage integration) |
 | Scraper | Python + Claude API (runs via GitHub Actions) |
+| Data feed | `data.json`, refreshed by the scraper and served to the frontend |
 
-The feedback form at the bottom of the page posts to `/api/submit`, which validates the payload and writes it to a `submissions` table in Neon. Submissions are reviewed directly in the [Neon console](https://console.neon.tech).
+The frontend fetches `/data.json`, renders the camp finder UI, and posts feedback or camp suggestions to `/api/submit`. The feedback endpoint validates submissions and writes them to Neon. Submissions are reviewed directly in the [Neon console](https://console.neon.tech).
+
+## Repository Layout
+
+```text
+src/                 React app
+api/                 Vercel serverless functions and schema
+scraper/             scraper logic and source definitions
+tests/               scraper tests
+data.json            latest scraped camp data
+.github/workflows/   scheduled scrape automation
+```
 
 ## Setup
 
-1. Fork or clone the repo
-2. Connect the repo to [Vercel](https://vercel.com) (Framework: Other, Output Directory: `.`)
-3. Add a Neon Postgres store via Vercel Storage — Vercel auto-injects `DATABASE_URL`
-4. Run `api/schema.sql` in the Neon SQL editor to create the `submissions` table
-5. Add your `ANTHROPIC_API_KEY` as a GitHub Actions secret (Settings → Secrets → Actions)
-6. Trigger the first scrape manually: Actions → Scrape Camp Data → Run workflow
+1. Clone the repo and install frontend dependencies with `npm install`
+2. Connect the repo to [Vercel](https://vercel.com)
+3. Add a Neon Postgres store in Vercel Storage so `DATABASE_URL` is available to `/api/submit`
+4. Run `api/schema.sql` in the Neon SQL editor to create or update the `submissions` table
+5. Add `ANTHROPIC_API_KEY` as a GitHub Actions secret for the scraper workflow
+6. Trigger the scrape workflow manually once from GitHub Actions if you need a fresh `data.json`
 
 ## Development
 
 ```bash
-npm install           # install test runner
-node --test api/validate.test.js   # 9 unit tests (API validation)
-python3 -m pytest                  # 31 scraper tests
+npm install
+npm run dev
 ```
+
+Useful checks:
+
+```bash
+npm run test:run
+node --test api/validate.test.js
+python3 -m pytest
+```
+
+## Deployment
+
+- `main` deploys to Vercel
+- pull requests get Vercel preview deployments
+- the scraper runs on a GitHub Actions schedule and commits refreshed `data.json` back to the repo

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -14,4 +14,14 @@ describe('App routing', () => {
       await screen.findByRole('heading', { name: /boston camp finder/i })
     ).toBeInTheDocument();
   });
+
+  it('shows the parent-run note in the site header', async () => {
+    const router = createMemoryRouter(appRoutes, { initialEntries: ['/'] });
+
+    render(<RouterProvider router={router} />);
+
+    expect(
+      await screen.findByText(/run by boston-area parents/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,14 +4,19 @@ export default function App() {
   return (
     <div className="min-h-screen bg-[#d8e0e8]">
       <header className="sticky top-0 z-40 border-b border-stone-200 bg-white shadow-sm">
-        <div className="mx-auto flex max-w-[1260px] items-center justify-between gap-4 px-6 py-[18px]">
-          <div className="flex items-baseline gap-3">
-            <h1 className="text-xl font-extrabold tracking-tight text-stone-900">
-              Boston Camp Finder
-            </h1>
-            <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-xs font-semibold text-teal-700">
-              📍 Roslindale
-            </span>
+        <div className="mx-auto flex max-w-[1260px] items-start justify-between gap-4 px-6 py-[18px]">
+          <div>
+            <div className="flex items-baseline gap-3">
+              <h1 className="text-xl font-extrabold tracking-tight text-stone-900">
+                Boston Camp Finder
+              </h1>
+              <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-xs font-semibold text-teal-700">
+                📍 Roslindale
+              </span>
+            </div>
+            <p className="mt-1 max-w-2xl text-sm text-stone-500">
+              Run by Boston-area parents who got tired of digging through scattered camp listings.
+            </p>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## What changed
- refreshed the README to reflect the current Vite + React + TypeScript frontend and deployment flow
- added a short parent-run note to the live site header
- added a regression test for the new header copy

## Why
The README still described the frontend as static HTML, and you wanted the site itself to explain that it is run by Boston-area parents.

## Validation
- `npm run test:run`