### PR TITLE
fix: sticky desktop column headers

### DIFF
--- a/src/features/finder/components/CampList.tsx
+++ b/src/features/finder/components/CampList.tsx
@@ -25,11 +25,11 @@ export default function CampList({ camps, savedCampIds, onToggleSavedCamp }: Cam
 
   return (
     <div
-      className="[overflow:clip] rounded-xl border border-stone-200 bg-white"
+      className="rounded-xl border border-stone-200 bg-white"
       style={{ boxShadow: '0 1px 3px rgba(28,25,23,0.06), 0 4px 16px rgba(28,25,23,0.05)' }}
     >
-      {/* Sticky desktop column header */}
-      <div className="hidden border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 sm:sticky sm:top-[61px] sm:z-10 sm:grid sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3">
+      {/* Sticky desktop column header — kept outside [overflow:clip] so position:sticky works */}
+      <div className="hidden border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 sm:sticky sm:top-[89px] sm:z-10 sm:grid sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3">
           <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
             Camp
           </div>
@@ -50,14 +50,17 @@ export default function CampList({ camps, savedCampIds, onToggleSavedCamp }: Cam
           </div>
       </div>
 
-      {camps.map((camp) => (
-        <CampCard
-          key={camp.id}
-          camp={camp}
-          isSaved={savedCampIds.has(camp.id)}
-          onToggleSaved={onToggleSavedCamp}
-        />
-      ))}
+      {/* overflow:clip on the inner wrapper (not the outer) so border-radius clips cards without breaking sticky */}
+      <div className="[overflow:clip] rounded-xl sm:rounded-t-none">
+        {camps.map((camp) => (
+          <CampCard
+            key={camp.id}
+            camp={camp}
+            isSaved={savedCampIds.has(camp.id)}
+            onToggleSaved={onToggleSavedCamp}
+          />
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Moved `[overflow:clip]` from the outer table container to an inner wrapper around the camp rows — browsers prevent `position:sticky` from working when an ancestor has `overflow:clip`
- Corrected the sticky `top` offset from `61px` to `89px` to match the actual nav bar height (the nav grew taller when the subtitle was added, but the offset was never updated)

## Test plan
- [ ] Scroll the camp list on a desktop-width window — column headers (Camp, Ages, Cost/wk, Distance, Link, Save) should stay pinned below the nav bar
- [ ] Confirm mobile filter bar sticky behavior is unchanged
- [ ] Confirm camp card border-radius clipping still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)