### PR TITLE
UX improvements: legibility, clear filters, org list affordance

### DIFF
--- a/src/features/finder/components/CampCard.tsx
+++ b/src/features/finder/components/CampCard.tsx
@@ -34,6 +34,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
   const primaryUrl = signupUrl ?? websiteUrl;
 
   const detailRows: [string, string | null | undefined][] = [
+    ['Organization', camp.organization || null],
     ['Location', camp.neighborhood || null],
     ['Hours', camp.hoursLabel || null],
     ['When', camp.weeksLabel || null],

--- a/src/features/finder/components/CampCard.tsx
+++ b/src/features/finder/components/CampCard.tsx
@@ -34,7 +34,6 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
   const primaryUrl = signupUrl ?? websiteUrl;
 
   const detailRows: [string, string | null | undefined][] = [
-    ['Organization', camp.organization || null],
     ['Location', camp.neighborhood || null],
     ['Hours', camp.hoursLabel || null],
     ['When', camp.weeksLabel || null],

--- a/src/features/finder/components/CampCard.tsx
+++ b/src/features/finder/components/CampCard.tsx
@@ -80,7 +80,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
         </div>
 
         {/* Ages */}
-        <div className="hidden text-right text-xs text-stone-400 sm:block">
+        <div className="hidden text-right text-xs text-stone-500 sm:block">
           {camp.ageRange || '—'}
         </div>
 
@@ -90,7 +90,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
         </div>
 
         {/* Distance */}
-        <div className="hidden text-right text-xs text-stone-400 sm:block">
+        <div className="hidden text-right text-xs text-stone-500 sm:block">
           {camp.distanceMiles != null ? `${camp.distanceMiles.toFixed(1)} mi` : '—'}
         </div>
 
@@ -136,10 +136,10 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
           <div className="grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-4">
             {detailRows.map(([label, value]) => (
               <div key={label}>
-                <div className="text-[10px] font-bold uppercase tracking-widest text-stone-400">
+                <div className="text-[11px] font-bold uppercase tracking-widest text-stone-500">
                   {label}
                 </div>
-                <div className={['mt-0.5 text-[13px] font-medium', value ? 'text-stone-700' : 'text-stone-300'].join(' ')}>
+                <div className={['mt-0.5 text-[13px] font-medium', value ? 'text-stone-700' : 'text-stone-400'].join(' ')}>
                   {value ?? '—'}
                 </div>
               </div>
@@ -190,7 +190,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
                 href={websiteUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="text-[13px] font-semibold text-stone-400 underline decoration-stone-200 hover:text-stone-600"
+                className="text-[13px] font-semibold text-stone-500 underline decoration-stone-300 hover:text-stone-700"
               >
                 Camp website
               </a>

--- a/src/features/finder/components/CampCard.tsx
+++ b/src/features/finder/components/CampCard.tsx
@@ -70,7 +70,7 @@ export default function CampCard({ camp, isSaved, onToggleSaved }: CampCardProps
             <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[13.5px] font-bold text-stone-900">
               {camp.name}
             </div>
-            <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] text-stone-400">
+            <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] text-stone-500">
               {camp.organization}
             </div>
             <div className="mt-0.5 text-[11px] font-medium text-stone-500 sm:hidden">

--- a/src/features/finder/components/CampList.tsx
+++ b/src/features/finder/components/CampList.tsx
@@ -29,23 +29,23 @@ export default function CampList({ camps, savedCampIds, onToggleSavedCamp }: Cam
       style={{ boxShadow: '0 1px 3px rgba(28,25,23,0.06), 0 4px 16px rgba(28,25,23,0.05)' }}
     >
       {/* Sticky desktop column header — kept outside [overflow:clip] so position:sticky works */}
-      <div className="hidden border-b-[1.5px] border-stone-200 bg-sand-100 px-4 py-2 sm:sticky sm:top-[89px] sm:z-10 sm:grid sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3">
-          <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-400">
+      <div className="hidden border-b-[1.5px] border-stone-200 bg-stone-50 px-4 py-2 sm:sticky sm:top-[89px] sm:z-10 sm:grid sm:grid-cols-[1fr_90px_100px_80px_32px_48px] sm:gap-3">
+          <div className="text-left text-[10px] font-bold uppercase tracking-widest text-stone-500">
             Camp
           </div>
-          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-400">
+          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-500">
             Ages
           </div>
-          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-400">
+          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-500">
             Cost / wk
           </div>
-          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-400">
+          <div className="text-right text-[10px] font-bold uppercase tracking-widest text-stone-500">
             Distance
           </div>
-          <div className="text-center text-[10px] font-bold uppercase tracking-widest text-stone-400">
+          <div className="text-center text-[10px] font-bold uppercase tracking-widest text-stone-500">
             Link
           </div>
-          <div className="text-center text-[10px] font-bold uppercase tracking-widest text-stone-400">
+          <div className="text-center text-[10px] font-bold uppercase tracking-widest text-stone-500">
             Save
           </div>
       </div>

--- a/src/features/finder/components/FilterBar.tsx
+++ b/src/features/finder/components/FilterBar.tsx
@@ -1,10 +1,12 @@
 import type { CampType, FinderFilters, FinderSeason, FinderSort } from '../types';
+import { DEFAULT_FINDER_FILTERS } from '../../../lib/share/shareState';
 
 interface FilterBarProps {
   filters: FinderFilters;
   typeOptions: CampType[];
   orgCounts: Record<string, number>;
   onFiltersChange: (updates: Partial<FinderFilters>) => void;
+  onResetFilters: () => void;
 }
 
 const inputCls =
@@ -51,14 +53,35 @@ export default function FilterBar({
   typeOptions,
   orgCounts,
   onFiltersChange,
+  onResetFilters,
 }: FilterBarProps) {
   const orgs = Object.keys(orgCounts).sort();
+
+  const isFiltered =
+    filters.query !== DEFAULT_FINDER_FILTERS.query ||
+    filters.type !== DEFAULT_FINDER_FILTERS.type ||
+    filters.age !== DEFAULT_FINDER_FILTERS.age ||
+    filters.maxDistance !== DEFAULT_FINDER_FILTERS.maxDistance ||
+    filters.maxCost !== DEFAULT_FINDER_FILTERS.maxCost ||
+    filters.aidFilter !== DEFAULT_FINDER_FILTERS.aidFilter ||
+    filters.season !== DEFAULT_FINDER_FILTERS.season ||
+    filters.freshnessFilter !== DEFAULT_FINDER_FILTERS.freshnessFilter ||
+    filters.selectedOrg !== DEFAULT_FINDER_FILTERS.selectedOrg;
 
   return (
     <div>
       {/* Header */}
-      <div className="border-b border-stone-100 bg-teal-50/50 px-4 py-3.5">
+      <div className="flex items-center justify-between border-b border-stone-100 bg-teal-50/50 px-4 py-3.5">
         <p className="text-[13px] font-bold text-teal-700">Find a good fit</p>
+        {isFiltered && (
+          <button
+            type="button"
+            onClick={onResetFilters}
+            className="text-[11px] font-semibold text-teal-600 hover:underline"
+          >
+            Clear all
+          </button>
+        )}
       </div>
 
       <div className="flex flex-col gap-3 overflow-y-auto px-4 py-4" style={{ maxHeight: 'calc(100dvh - 180px)' }}>

--- a/src/features/finder/components/FilterBar.tsx
+++ b/src/features/finder/components/FilterBar.tsx
@@ -241,7 +241,7 @@ export default function FilterBar({
                 ← All organizations
               </button>
             )}
-            <div className="flex max-h-52 flex-col gap-0.5 overflow-y-auto">
+            <div className="flex max-h-52 flex-col gap-0.5 overflow-y-auto rounded-lg border border-stone-200 bg-stone-50/50 p-1">
               {orgs.map((org) => (
                 <button
                   key={org}

--- a/src/features/finder/components/FilterBar.tsx
+++ b/src/features/finder/components/FilterBar.tsx
@@ -229,7 +229,7 @@ export default function FilterBar({
                     })
                   }
                   className={[
-                    'flex items-center justify-between rounded px-2 py-1.5 text-left text-xs font-medium transition',
+                    'flex items-center justify-between rounded px-2 py-1.5 text-left text-sm font-medium transition',
                     org === filters.selectedOrg
                       ? 'bg-teal-600 text-white'
                       : 'text-stone-700 hover:bg-stone-50',

--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -4,9 +4,23 @@ import FilterBar from './FilterBar';
 import CampList from './CampList';
 import ResultsSummary from './ResultsSummary';
 import SavedControls from './SavedControls';
+import { DEFAULT_FINDER_FILTERS } from '../../../lib/share/shareState';
 
 export default function FinderLayout(finder: FinderState) {
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+
+  const f = finder.filters;
+  const activeFilterCount = [
+    f.query !== DEFAULT_FINDER_FILTERS.query,
+    f.type !== DEFAULT_FINDER_FILTERS.type,
+    f.age !== DEFAULT_FINDER_FILTERS.age,
+    f.maxDistance !== DEFAULT_FINDER_FILTERS.maxDistance,
+    f.maxCost !== DEFAULT_FINDER_FILTERS.maxCost,
+    f.aidFilter !== DEFAULT_FINDER_FILTERS.aidFilter,
+    f.season !== DEFAULT_FINDER_FILTERS.season,
+    f.freshnessFilter !== DEFAULT_FINDER_FILTERS.freshnessFilter,
+    f.selectedOrg !== DEFAULT_FINDER_FILTERS.selectedOrg,
+  ].filter(Boolean).length;
 
   const sidebar = (
     <div
@@ -130,6 +144,11 @@ export default function FinderLayout(finder: FinderState) {
                   className="flex items-center gap-1.5 rounded-full border border-stone-300 bg-white px-3 py-1.5 text-xs font-semibold text-stone-700 shadow-sm hover:bg-stone-50"
                 >
                   ⚙ Filters
+                  {activeFilterCount > 0 && (
+                    <span className="rounded-full bg-teal-600 px-1.5 py-0.5 text-[10px] font-bold leading-none text-white">
+                      {activeFilterCount}
+                    </span>
+                  )}
                   {finder.savedCount > 0 && (
                     <span className="rounded-full bg-amber-400 px-1.5 py-0.5 text-[10px] font-bold leading-none text-white">
                       {finder.savedCount}

--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -18,6 +18,7 @@ export default function FinderLayout(finder: FinderState) {
         typeOptions={finder.typeOptions}
         orgCounts={finder.orgCounts}
         onFiltersChange={finder.setFilters}
+        onResetFilters={finder.resetFilters}
       />
 
       {(finder.savedCount > 0 || finder.filters.savedOnly) && (


### PR DESCRIPTION
## Summary

- Bumps org name on camp cards and sidebar org list buttons to higher contrast colors
- Fixes invalid `bg-sand-100` class on column header row (was rendering transparent)
- Steps up text contrast across column headers, ages, distance, detail labels, and empty values
- Adds "Clear all" button to FilterBar header — appears when any non-default filter is active
- Adds active filter count badge (teal) to mobile Filters button alongside existing saved badge
- Adds border + background to org list to signal it's a scrollable section

Closes part of #14.

## Test plan
- [ ] Column header row looks consistent with the rest of the table
- [ ] "Clear all" appears in sidebar when filters are active and resets everything
- [ ] Mobile filter button shows teal count badge when filters are active
- [ ] Org list in sidebar has visible border and scroll affordance
- [ ] All text is legible at a glance without squinting

🤖 Generated with [Claude Code](https://claude.com/claude-code)