### PR TITLE
Fix sticky mobile filter bar hidden behind header

### DIFF
--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -137,7 +137,7 @@ export default function FinderLayout(finder: FinderState) {
                 totalCount={finder.camps.length}
               />
 
-              <div className="sticky top-[61px] z-20 -mx-3 border-y border-stone-200 bg-[#d8e0e8]/95 px-3 py-2 backdrop-blur-sm lg:hidden">
+              <div className="sticky top-[110px] z-20 -mx-3 border-y border-stone-200 bg-[#d8e0e8]/95 px-3 py-2 backdrop-blur-sm sm:top-[89px] lg:hidden">
                 <button
                   type="button"
                   onClick={() => setMobileFiltersOpen(true)}


### PR DESCRIPTION
## Summary

- The mobile filter bar had `sticky top-[61px]` but the app header is ~89px tall (taller on narrow screens where the subtitle wraps to 2 lines)
- The bar was sticking correctly but hidden behind the header — appearing invisible until scrolling back to the top
- Fixed with `top-[110px]` on mobile and `sm:top-[89px]` on tablet

## Test plan
- [ ] On mobile/narrow browser, scroll down through results — filter bar stays visible below the header
- [ ] Works at both narrow (<640px) and tablet (640px–1024px) widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)