### PR TITLE
feat: add CSV download to Saved tab

### DIFF
--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -153,6 +153,7 @@ export default function FinderLayout(finder: FinderState) {
                     <SavedControls
                       savedCount={finder.savedCount}
                       savedCampIds={finder.savedCampIds}
+                      savedCamps={finder.savedCamps}
                       onClearSaved={finder.clearSavedCamps}
                     />
                   </div>

--- a/src/features/finder/components/SavedControls.tsx
+++ b/src/features/finder/components/SavedControls.tsx
@@ -1,17 +1,59 @@
 import { useState } from 'react';
+import type { Camp } from '../types';
 
 interface SavedControlsProps {
   savedCount: number;
   savedCampIds: Set<string>;
+  savedCamps: Camp[];
   onClearSaved: () => void;
+}
+
+function csvCell(value: string | number | boolean | null | undefined): string {
+  if (value == null) return '""';
+  const s = String(value);
+  return `"${s.replace(/"/g, '""')}"`;
 }
 
 export default function SavedControls({
   savedCount,
   savedCampIds,
+  savedCamps,
   onClearSaved,
 }: SavedControlsProps) {
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied'>('idle');
+
+  function downloadCsv() {
+    const headers = [
+      'Name', 'Organization', 'Type', 'Ages', 'Neighborhood', 'Address',
+      'Distance (mi)', 'Hours', 'Schedule', 'Cost/Week', 'Financial Aid',
+      'Signup Opens', 'Website', 'Signup URL',
+    ];
+    const rows = savedCamps.map((c) => [
+      c.name,
+      c.organization,
+      c.type,
+      c.ageRange,
+      c.neighborhood,
+      c.address,
+      c.distanceMiles ?? '',
+      c.hoursLabel,
+      c.weeksLabel,
+      c.costLabel,
+      c.financialAidAvailable === true ? 'Yes' : c.financialAidAvailable === false ? 'No' : '',
+      c.signupOpensLabel,
+      c.websiteUrl ?? '',
+      c.signupUrl ?? '',
+    ].map(csvCell).join(','));
+
+    const csv = [headers.map(csvCell).join(','), ...rows].join('\r\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'saved-camps.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
 
   function copyShareLink() {
     const ids = Array.from(savedCampIds).join(',');
@@ -62,6 +104,13 @@ export default function SavedControls({
           ].join(' ')}
         >
           {copyStatus === 'copied' ? '✓ Copied!' : '🔗 Copy link'}
+        </button>
+        <button
+          type="button"
+          onClick={downloadCsv}
+          className="rounded-lg border border-stone-200 px-2.5 py-1 text-xs font-semibold text-stone-700 transition hover:bg-stone-50"
+        >
+          ↓ CSV
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

- Adds a **↓ CSV** button to the SavedControls toolbar on the Saved tab
- Downloads `saved-camps.csv` — opens directly in Excel or Google Sheets
- Columns: Name, Organization, Type, Ages, Neighborhood, Address, Distance (mi), Hours, Schedule, Cost/Week, Financial Aid, Signup Opens, Website, Signup URL
- No new dependencies — uses `Blob` + `URL.createObjectURL`

## Test plan

- [ ] Star a few camps, switch to Saved tab, click ↓ CSV
- [ ] File downloads as `saved-camps.csv`
- [ ] Opens cleanly in Excel / Google Sheets with correct column headers
- [ ] Fields with commas or quotes are properly escaped
- [ ] All 36 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)