### PR TITLE
Remove data year filter and simplify results summary

### DIFF
--- a/src/features/finder/components/FilterBar.tsx
+++ b/src/features/finder/components/FilterBar.tsx
@@ -66,7 +66,6 @@ export default function FilterBar({
     filters.maxCost !== DEFAULT_FINDER_FILTERS.maxCost ||
     filters.aidFilter !== DEFAULT_FINDER_FILTERS.aidFilter ||
     filters.season !== DEFAULT_FINDER_FILTERS.season ||
-    filters.freshnessFilter !== DEFAULT_FINDER_FILTERS.freshnessFilter ||
     filters.selectedOrg !== DEFAULT_FINDER_FILTERS.selectedOrg;
 
   return (
@@ -197,36 +196,18 @@ export default function FilterBar({
           </select>
         </div>
 
-        {/* Data year + Sort */}
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <label className={labelCls}>Data year</label>
-            <select
-              className={selectCls}
-              value={filters.freshnessFilter}
-              onChange={(e) =>
-                onFiltersChange({
-                  freshnessFilter: e.target.value as FinderFilters['freshnessFilter'],
-                })
-              }
-            >
-              <option value="all">Any</option>
-              <option value="current">Current</option>
-              <option value="stale">Prior</option>
-            </select>
-          </div>
-          <div>
-            <label className={labelCls}>Sort</label>
-            <select
-              className={selectCls}
-              value={filters.sort}
-              onChange={(e) => onFiltersChange({ sort: e.target.value as FinderSort })}
-            >
-              {SORT_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
-              ))}
-            </select>
-          </div>
+        {/* Sort */}
+        <div>
+          <label className={labelCls}>Sort</label>
+          <select
+            className={selectCls}
+            value={filters.sort}
+            onChange={(e) => onFiltersChange({ sort: e.target.value as FinderSort })}
+          >
+            {SORT_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
         </div>
 
         {/* Organization list */}

--- a/src/features/finder/components/FinderLayout.test.tsx
+++ b/src/features/finder/components/FinderLayout.test.tsx
@@ -62,7 +62,6 @@ function makeFinderState(overrides: Partial<FinderState> = {}): FinderState {
     setSort: vi.fn(),
     setMaxCost: vi.fn(),
     setAidFilter: vi.fn(),
-    setFreshnessFilter: vi.fn(),
     setSelectedOrg: vi.fn(),
     selectCamp: vi.fn(),
     toggleSavedCamp: vi.fn(),

--- a/src/features/finder/components/FinderLayout.tsx
+++ b/src/features/finder/components/FinderLayout.tsx
@@ -23,7 +23,6 @@ export default function FinderLayout(finder: FinderState) {
     f.maxCost !== DEFAULT_FINDER_FILTERS.maxCost,
     f.aidFilter !== DEFAULT_FINDER_FILTERS.aidFilter,
     f.season !== DEFAULT_FINDER_FILTERS.season,
-    f.freshnessFilter !== DEFAULT_FINDER_FILTERS.freshnessFilter,
     f.selectedOrg !== DEFAULT_FINDER_FILTERS.selectedOrg,
   ].filter(Boolean).length;
 

--- a/src/features/finder/components/ResultsSummary.tsx
+++ b/src/features/finder/components/ResultsSummary.tsx
@@ -10,33 +10,22 @@ export default function ResultsSummary({ visibleCamps, totalCount }: ResultsSumm
   const closeCount = visibleCamps.filter(
     (c) => (c.distanceMiles ?? Infinity) <= 2,
   ).length;
-  const latestYear = visibleCamps.reduce<number | null>((best, c) => {
-    if (c.dataYear == null) return best;
-    return best == null || c.dataYear > best ? c.dataYear : best;
-  }, null);
 
   const stats = [
-    { value: visibleCamps.length, label: 'matching camps' },
+    { value: visibleCamps.length, label: `of ${totalCount} camps` },
     { value: aidCount, label: 'with aid' },
     { value: closeCount, label: 'within 2 mi' },
-    { value: latestYear ?? '—', label: 'latest data' },
   ];
-
-  void totalCount;
 
   return (
     <div
-      className="grid grid-cols-2 overflow-hidden rounded-xl border border-stone-200 bg-white lg:grid-cols-4"
+      className="grid grid-cols-3 overflow-hidden rounded-xl border border-stone-200 bg-white"
       style={{ boxShadow: '0 1px 3px rgba(28,25,23,0.06), 0 4px 16px rgba(28,25,23,0.05)' }}
     >
       {stats.map(({ value, label }, i) => (
         <div
           key={label}
-          className={[
-            'p-4',
-            i < 3 ? 'border-b border-r border-stone-100 lg:border-b-0' : 'border-b border-stone-100 lg:border-b-0',
-            i % 2 === 0 && i < 2 ? '' : '',
-          ].join(' ')}
+          className={['p-4', i < 2 ? 'border-r border-stone-100' : ''].join(' ')}
         >
           <div className="text-[22px] font-extrabold leading-none text-stone-900">{value}</div>
           <div className="mt-1 text-[11px] text-stone-400">{label}</div>

--- a/src/features/finder/hooks/useFinderState.ts
+++ b/src/features/finder/hooks/useFinderState.ts
@@ -6,7 +6,6 @@ import type {
   CampType,
   FinderAidFilter,
   FinderFilters,
-  FinderFreshnessFilter,
   FinderSeason,
   FinderSort,
 } from '../types';
@@ -50,7 +49,6 @@ export interface FinderState {
   setSort: (sort: FinderSort) => void;
   setMaxCost: (maxCost: number | null) => void;
   setAidFilter: (aid: FinderAidFilter) => void;
-  setFreshnessFilter: (fresh: FinderFreshnessFilter) => void;
   setSelectedOrg: (org: string | null) => void;
   selectCamp: (campId: string | null) => void;
   toggleSavedCamp: (campId: string) => void;
@@ -238,7 +236,6 @@ export function useFinderState(): FinderState {
     setSort: (sort) => updateFilters({ sort }),
     setMaxCost: (maxCost) => updateFilters({ maxCost }),
     setAidFilter: (aidFilter) => updateFilters({ aidFilter }),
-    setFreshnessFilter: (freshnessFilter) => updateFilters({ freshnessFilter }),
     setSelectedOrg: (selectedOrg) => updateFilters({ selectedOrg }),
     selectCamp: (campId) => setSelectedCampId(campId),
     toggleSavedCamp: (campId) =>

--- a/src/features/finder/types.ts
+++ b/src/features/finder/types.ts
@@ -19,7 +19,6 @@ export type CampType =
 export type FinderSort = 'distance' | 'name' | 'cost' | 'current';
 export type FinderSeason = 'spring' | 'summer' | 'fall' | 'winter' | 'all';
 export type FinderAidFilter = 'yes' | 'known' | 'all';
-export type FinderFreshnessFilter = 'current' | 'stale' | 'all';
 
 export interface RawCampRecord {
   camp_name?: unknown;
@@ -74,6 +73,5 @@ export interface FinderFilters {
   sort: FinderSort;
   maxCost: number | null;
   aidFilter: FinderAidFilter;
-  freshnessFilter: FinderFreshnessFilter;
   selectedOrg: string | null;
 }

--- a/src/lib/filters/applyFilters.test.ts
+++ b/src/lib/filters/applyFilters.test.ts
@@ -146,7 +146,6 @@ function makeFilters(overrides: Partial<FinderFilters> = {}): FinderFilters {
     sort: 'distance',
     maxCost: null,
     aidFilter: 'all',
-    freshnessFilter: 'all',
     selectedOrg: null,
     ...overrides,
   };
@@ -358,15 +357,6 @@ describe('applyFilters', () => {
     const aidKnown = applyFilters(camps, makeFilters({ aidFilter: 'known' }));
     expect(aidKnown.every((c) => c.financialAidAvailable != null)).toBe(true);
     expect(aidKnown.some((c) => c.financialAidAvailable === false)).toBe(true);
-  });
-
-  it('filters by data freshness', () => {
-    const current = applyFilters(camps, makeFilters({ freshnessFilter: 'current' }));
-    expect(current.every((c) => !c.isStale)).toBe(true);
-
-    const stale = applyFilters(camps, makeFilters({ freshnessFilter: 'stale' }));
-    expect(stale.every((c) => c.isStale)).toBe(true);
-    expect(stale.map((c) => c.id)).toContain('museum-of-science-robotics-lab');
   });
 
   it('filters by organization name', () => {

--- a/src/lib/filters/applyFilters.ts
+++ b/src/lib/filters/applyFilters.ts
@@ -224,11 +224,6 @@ export function applyFilters(
       if (filters.aidFilter === 'known') return camp.financialAidAvailable != null;
       return true;
     })
-    .filter((camp) => {
-      if (filters.freshnessFilter === 'current') return !camp.isStale;
-      if (filters.freshnessFilter === 'stale') return camp.isStale;
-      return true;
-    })
     .filter((camp) =>
       filters.selectedOrg == null || camp.organization === filters.selectedOrg,
     )

--- a/src/lib/share/shareState.ts
+++ b/src/lib/share/shareState.ts
@@ -2,7 +2,6 @@ import type {
   CampType,
   FinderAidFilter,
   FinderFilters,
-  FinderFreshnessFilter,
   FinderSeason,
   FinderSort,
 } from '../../features/finder/types';
@@ -16,7 +15,6 @@ export const DEFAULT_FINDER_FILTERS: FinderFilters = {
   sort: 'distance',
   maxCost: null,
   aidFilter: 'all',
-  freshnessFilter: 'all',
   selectedOrg: null,
 };
 
@@ -46,10 +44,6 @@ function isAidFilter(value: string | null): value is FinderAidFilter {
   return value === 'yes' || value === 'known' || value === 'all';
 }
 
-function isFreshnessFilter(value: string | null): value is FinderFreshnessFilter {
-  return value === 'current' || value === 'stale' || value === 'all';
-}
-
 function normalizeSearch(search: string): URLSearchParams {
   return new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
 }
@@ -67,7 +61,6 @@ export function parseFinderShareState(search: string): FinderShareState {
   const seasonParam = params.get('season');
   const sortParam = params.get('sort');
   const aidParam = params.get('aid');
-  const freshParam = params.get('fresh');
 
   return {
     filters: {
@@ -79,7 +72,6 @@ export function parseFinderShareState(search: string): FinderShareState {
       sort: isFinderSort(sortParam) ? sortParam : DEFAULT_FINDER_FILTERS.sort,
       maxCost: parseNullableNumber(params.get('maxCost')),
       aidFilter: isAidFilter(aidParam) ? aidParam : DEFAULT_FINDER_FILTERS.aidFilter,
-      freshnessFilter: isFreshnessFilter(freshParam) ? freshParam : DEFAULT_FINDER_FILTERS.freshnessFilter,
       selectedOrg: params.get('org')?.trim() || null,
     },
     selectedCampId: params.get('selected')?.trim() || null,
@@ -122,10 +114,6 @@ export function stringifyFinderShareState(state: FinderShareState): string {
     params.set('aid', filters.aidFilter);
   }
 
-  if (filters.freshnessFilter !== DEFAULT_FINDER_FILTERS.freshnessFilter) {
-    params.set('fresh', filters.freshnessFilter);
-  }
-
   if (filters.selectedOrg != null) {
     params.set('org', filters.selectedOrg);
   }
@@ -143,7 +131,6 @@ export function hasActiveFinderFilters(filters: FinderFilters): boolean {
     filters.sort !== DEFAULT_FINDER_FILTERS.sort ||
     filters.maxCost != null ||
     filters.aidFilter !== DEFAULT_FINDER_FILTERS.aidFilter ||
-    filters.freshnessFilter !== DEFAULT_FINDER_FILTERS.freshnessFilter ||
     filters.selectedOrg != null
   );
 }


### PR DESCRIPTION
## Summary
- Removes the "Data year" filter from the sidebar — users always want current data, so filtering by stale/current isn't useful
- Drops `FinderFreshnessFilter` type and `freshnessFilter` from filters everywhere (types, state, URL params, apply logic, UI)
- Sort filter gets its own full-width row instead of sharing a 2-column grid
- Simplifies the results summary from 4 stats to 3: matching/total camps, with aid, within 2 mi — drops the "latest data year" stat

## Test plan
- [ ] Filter sidebar no longer shows "Data year" select
- [ ] Sort filter is full-width
- [ ] Results summary shows 3 stats in a row
- [ ] All 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)